### PR TITLE
fix(model/test): emumerations are correctly spelled as enumerations now

### DIFF
--- a/resources/bpmn-io/json/bioc.json
+++ b/resources/bpmn-io/json/bioc.json
@@ -36,6 +36,6 @@
       ]
     }
   ],
-  "emumerations": [],
+  "enumerations": [],
   "associations": []
 }

--- a/resources/bpmn/json/bpmn.json
+++ b/resources/bpmn/json/bpmn.json
@@ -2814,7 +2814,7 @@
       ]
     }
   ],
-  "emumerations": [
+  "enumerations": [
     {
       "name": "ProcessType",
       "literalValues": [

--- a/resources/bpmn/json/bpmndi.json
+++ b/resources/bpmn/json/bpmndi.json
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "emumerations": [
+  "enumerations": [
     {
       "name": "ParticipantBandKind",
       "literalValues": [

--- a/test/fixtures/json/model/camunda.json
+++ b/test/fixtures/json/model/camunda.json
@@ -220,5 +220,5 @@
       "superClass": [ "InputOutputParameter" ]
     }
   ],
-  "emumerations": [ ]
+  "enumerations": [ ]
 }


### PR DESCRIPTION
Commit should say it all - in case you wonder: tests won't pass on bpmn-io/bpmn-moddle as well.