### PR TITLE
Rename participantRef on ChoreographyActivity

### DIFF
--- a/resources/bpmn/json/bpmn.json
+++ b/resources/bpmn/json/bpmn.json
@@ -1388,7 +1388,7 @@
           "type": "String"
         },
         {
-          "name": "participantRefs",
+          "name": "participantRef",
           "type": "Participant",
           "isMany": true,
           "isReference": true
@@ -2061,7 +2061,7 @@
       ],
       "properties": [
         {
-          "name": "participantRefs",
+          "name": "participantRef",
           "type": "Participant",
           "isMany": true,
           "isReference": true
@@ -2135,8 +2135,8 @@
     {
       "name": "Choreography",
       "superClass": [
-        "FlowElementsContainer",
-        "Collaboration"
+        "Collaboration",
+        "FlowElementsContainer"
       ]
     },
     {

--- a/test/fixtures/bpmn/choreography-task.bpmn
+++ b/test/fixtures/bpmn/choreography-task.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:signavio="http://www.signavio.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="Signavio Process Editor, http://www.signavio.com" exporterVersion="8.4.1" expressionLanguage="http://www.w3.org/1999/XPath" id="sid-73c85f47-caf7-49f4-81c2-ccd9c46beedb" targetNamespace="http://www.signavio.com/bpmn20" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <message id="someMessage" />
+  <choreography id="Choreography_1" name="Default Choreography">
+    <participant id="Participant_1" name="Initiating Participant"/>
+    <participant id="Participant_2" name="Non-initiating Participant"/>
+    <messageFlow id="MessageFlow" messageRef="someMessage" name="Message Flow" sourceRef="Participant_1" targetRef="Participant_2"/>
+    <choreographyTask id="ChoreographyTask_1" name="Choreography Task" initiatingParticipantRef="Participant_1">
+      <incoming>SequenceFlow_2</incoming>
+      <outgoing>SequenceFlow_1</outgoing>
+      <participantRef>Participant_1</participantRef>
+      <participantRef>Participant_2</participantRef>
+      <messageFlowRef>MessageFlow</messageFlowRef>
+    </choreographyTask>
+    <endEvent id="EndEvent_1" name="End Event 1">
+      <incoming>SequenceFlow_1</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_1" sourceRef="ChoreographyTask_1" targetRef="EndEvent_1"/>
+    <startEvent id="StartEvent_1" name="Start Event 1">
+      <outgoing>SequenceFlow_2</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_2" sourceRef="StartEvent_1" targetRef="ChoreographyTask_1"/>
+  </choreography>
+</definitions>

--- a/test/spec/adapter/cmof/generate-simple.js
+++ b/test/spec/adapter/cmof/generate-simple.js
@@ -203,6 +203,13 @@ describe('moddle BPMN 2.0 json', function() {
         });
 
 
+        // fix Choreography child element order by swapping the super classes
+        // (Collaboration children should come before FlowElementsContainer children)
+        builder.alter('Choreography', function(desc) {
+          desc.superClass = [ 'Collaboration', 'FlowElementsContainer' ];
+        });
+
+
         // fix Activity order serialization
 
         builder.alter('Activity', function(desc) {
@@ -245,6 +252,14 @@ describe('moddle BPMN 2.0 json', function() {
 
         builder.alter('DataOutput#outputSetRefs', {
           name: 'outputSetRef'
+        });
+
+        builder.alter('ChoreographyActivity#participantRefs', {
+          name: 'participantRef'
+        });
+
+        builder.alter('ConversationNode#participantRefs', {
+          name: 'participantRef'
         });
 
 

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -463,6 +463,25 @@ describe('bpmn-moddle - roundtrip', function() {
     });
 
 
+    it('choreography task', function(done) {
+
+      // given
+      fromFile('test/fixtures/bpmn/choreography-task.bpmn', function(err, result) {
+
+        if (err) {
+          return done(err);
+        }
+
+        // when
+        toXML(result, { format: true }, function(err, xml) {
+
+          validate(err, xml, done);
+        });
+      });
+
+    });
+
+
     it('simple processElement', function(done) {
 
       // given


### PR DESCRIPTION
Resolves #59 (more info there).

Changes the generation process to rename two `participantRefs` associations to `participantRef` (on `ChoreographyActivity` and `ConversationNode`). Also changes the order of the properties of choreography activities.

A test case is added for a simple choreography with one task and a few participants.