### PR TITLE
Verifies nested local namespace serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,13 +1310,13 @@
       }
     },
     "moddle-xml": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.0.tgz",
-      "integrity": "sha512-5QJZkQj1v3nqZn+hlEmZDgTEVWif+VOgXx69SRoDJuqdXgIJn/cKqiSeNsA3yYy9yYGWUNwk5e+Zi04FWYj4lg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.1.tgz",
+      "integrity": "sha512-AXT3C1XGxo2h2ckk9hz62MY/spDobyhR+A2o30it0ZAO/NFDWpzYm+y/WeC52XrWi/MzUrVz8JVtfJu+W2DESA==",
       "requires": {
         "min-dash": "^3.0.0",
         "moddle": "^5.0.1",
-        "saxen": "^8.1.1"
+        "saxen": "^8.1.2"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   "dependencies": {
     "min-dash": "^3.0.0",
     "moddle": "^5.0.1",
-    "moddle-xml": "^9.0.0"
+    "moddle-xml": "^9.0.1"
   }
 }

--- a/test/fixtures/bpmn/namespace-redefinition.bpmn
+++ b/test/fixtures/bpmn/namespace-redefinition.bpmn
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions" targetNamespace="http://bpmn.io">
+  <process id="Process_1">
+    <dataObjectReference xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" id="DataObjectReference_1" />
+    <foo:userTask xmlns:foo="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Task_1" name="Task 1" />
+  </process>
+  <BPMNDiagram xmlns="http://www.omg.org/spec/BPMN/20100524/DI" id="BPMNDiagram_1">
+    <BPMNPlane xmlns="http://www.omg.org/spec/BPMN/20100524/DI" bpmnElement="Definitions" />
+  </BPMNDiagram>
+</definitions>

--- a/test/fixtures/bpmn/redundant-ns-declaration.bpmn
+++ b/test/fixtures/bpmn/redundant-ns-declaration.bpmn
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<definitions id="Definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" targetNamespace="http://bpmn.io">
+  <BPMNDiagram id="BPMNDiagram_1" xmlns="http://www.omg.org/spec/BPMN/20100524/DI">
+    <BPMNPlane bpmnElement="Definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/DI" />
+  </BPMNDiagram>
+</definitions>

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -11,6 +11,10 @@ import {
   validate
 } from '../../xml-helper';
 
+import {
+  readFileSync as readFile
+} from 'fs';
+
 
 describe('bpmn-moddle - roundtrip', function() {
 
@@ -591,10 +595,29 @@ describe('bpmn-moddle - roundtrip', function() {
 
       // local namespace declaration is exported
       expect(xml).to.contain(
-        '<BPMNDiagram id="BPMNDiagram_1" xmlns="http://www.omg.org/spec/BPMN/20100524/DI">'
+        '<BPMNDiagram xmlns="http://www.omg.org/spec/BPMN/20100524/DI" id="BPMNDiagram_1">'
       );
 
       await validate(xml);
+    });
+
+
+    it('local namespace exports', async function() {
+
+      // given
+      var expectedXML = readFile('test/fixtures/bpmn/namespace-redefinition.bpmn', 'utf8');
+
+      var {
+        rootElement
+      } = await fromFile('test/fixtures/bpmn/namespace-redefinition.bpmn');
+
+      // when
+      var {
+        xml
+      } = await toXML(rootElement, { format: true });
+
+      // then
+      expect(xml).to.eql(expectedXML);
     });
 
   });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -570,6 +570,33 @@ describe('bpmn-moddle - roundtrip', function() {
       await validate(xml);
     });
 
+
+    it('local namespace declaration / re-definition', async function() {
+
+      // given
+      var {
+        rootElement
+      } = await fromFile('test/fixtures/bpmn/redundant-ns-declaration.bpmn');
+
+      // when
+      var {
+        xml
+      } = await toXML(rootElement, { format: true });
+
+      // then
+      // unused namespace declaration is cleaned up
+      expect(xml).not.to.contain(
+        'xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"'
+      );
+
+      // local namespace declaration is exported
+      expect(xml).to.contain(
+        '<BPMNDiagram id="BPMNDiagram_1" xmlns="http://www.omg.org/spec/BPMN/20100524/DI">'
+      );
+
+      await validate(xml);
+    });
+
   });
 
 
@@ -644,6 +671,8 @@ describe('bpmn-moddle - roundtrip', function() {
         var {
           xml
         } = await toXML(rootElement, { format: true });
+
+        // then
         await validate(xml);
       });
 


### PR DESCRIPTION
Verifies https://github.com/bpmn-io/bpmn-js/issues/1310 is fixed.

Requires fixed and released `moddle-xml@9.x`.