### PR TITLE
Verify nested local namespace declaration (6.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmn-moddle](https://github.com/bpmn-io/bpmn-moddle) are
 
 ___Note:__ Yet to be released changes appear here._
 
+## 6.0.5
+
+* `FIX`: account for local namespace declaration overrides ([#76](https://github.com/bpmn-io/bpmn-moddle/pull/76))
+* `CHORE`: bump to `moddle-xml@8.0.6`
+
 ## 6.0.4
 
 * `CHORE`: bump to `moddle-xml@8.0.5`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,9 +1310,9 @@
       }
     },
     "moddle-xml": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.5.tgz",
-      "integrity": "sha512-c7foDi7pUTHIL00UBu5jEM/oIgasuoueVIrBa0Tg1EvWdDgdGprw2nyDPuEzVafthzKGd0lxFoO+U1ENcldrCQ==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.6.tgz",
+      "integrity": "sha512-ine4zIKXMulFQWp6B7c7qmkQIuvCuFWszSflaxGtDC7cXZ3dpxVIQDatjgBZUB4S2vCskFhKT0EP8ngiJmoVIg==",
       "requires": {
         "min-dash": "^3.0.0",
         "moddle": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   "dependencies": {
     "min-dash": "^3.0.0",
     "moddle": "^5.0.1",
-    "moddle-xml": "^8.0.5"
+    "moddle-xml": "^8.0.6"
   }
 }

--- a/test/fixtures/bpmn/redundant-ns-declaration.bpmn
+++ b/test/fixtures/bpmn/redundant-ns-declaration.bpmn
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<definitions id="Definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" targetNamespace="http://bpmn.io">
+  <BPMNDiagram id="BPMNDiagram_1" xmlns="http://www.omg.org/spec/BPMN/20100524/DI">
+    <BPMNPlane bpmnElement="Definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/DI" />
+  </BPMNDiagram>
+</definitions>

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -622,6 +622,40 @@ describe('bpmn-moddle - roundtrip', function() {
       });
     });
 
+
+    it('local namespace declaration / re-definition', function(done) {
+
+      // given
+      fromFile('test/fixtures/bpmn/redundant-ns-declaration.bpmn', function(err, result) {
+
+        if (err) {
+          return done(err);
+        }
+
+        // when
+        toXML(result, { format: true }, function(err, xml) {
+
+          if (err) {
+            return done(err);
+          }
+
+          // then
+          // unused namespace declaration is cleaned up
+          expect(xml).not.to.contain(
+            'xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"'
+          );
+
+          // local namespace declaration is exported
+          expect(xml).to.contain(
+            '<BPMNDiagram xmlns="http://www.omg.org/spec/BPMN/20100524/DI" id="BPMNDiagram_1">'
+          );
+
+          validate(err, xml, done);
+        });
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
Verifies https://github.com/bpmn-io/bpmn-js/issues/1310 is fixed.

Requires fixed + released `moddle-xml@8.x`.

Backport of https://github.com/bpmn-io/bpmn-moddle/pull/75.