### PR TITLE
fix: adjusted DataAssociation model to match bpmn spec

### DIFF
--- a/resources/bpmn/json/bpmn.json
+++ b/resources/bpmn/json/bpmn.json
@@ -946,6 +946,11 @@
       ],
       "properties": [
         {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
           "name": "sourceRef",
           "type": "ItemAwareElement",
           "isMany": true,

--- a/tasks/transforms/transformBPMN.js
+++ b/tasks/transforms/transformBPMN.js
@@ -140,15 +140,25 @@ module.exports = async function(results) {
     model
   );
 
-  model = orderProperties('DataAssociation', [
-    'sourceRef',
-    'targetRef',
-    'transformation'
-  ], model);
-
   findProperty('DataAssociation#transformation', model).xml = {
     serialize: 'property'
   };
+
+  const dataAssociation = findType('DataAssociation', model);
+
+  dataAssociation.properties.push({
+    name: 'name',
+    isAttr: true,
+    type: 'String'
+  });
+
+  model = orderProperties('DataAssociation', [
+    'name',
+    'sourceRef',
+    'targetRef',
+    'transformation',
+    'assignment'
+  ], model);
 
   findType('Choreography', model).superClass = [ 'Collaboration', 'FlowElementsContainer' ];
 
@@ -164,13 +174,6 @@ module.exports = async function(results) {
     'resources',
     'completionQuantity',
     'loopCharacteristics'
-  ], model);
-
-  model = orderProperties('DataAssociation', [
-    'sourceRef',
-    'targetRef',
-    'transformation',
-    'assignment'
   ], model);
 
   findProperty('CallableElement#supportedInterfaceRefs', model).name = 'supportedInterfaceRef';

--- a/test/fixtures/bpmn/catch-event-dataOutputAssociations.part.bpmn
+++ b/test/fixtures/bpmn/catch-event-dataOutputAssociations.part.bpmn
@@ -1,5 +1,5 @@
 <bpmn:startEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
               id="StartEvent_1">
-  <bpmn:dataOutputAssociation id="DataOutputAssociation_1"></bpmn:dataOutputAssociation>
+  <bpmn:dataOutputAssociation id="DataOutputAssociation_1" name="DataOutputAssociation_1n"></bpmn:dataOutputAssociation>
 </bpmn:startEvent>

--- a/test/fixtures/bpmn/throw-event-dataInputAssociations.part.bpmn
+++ b/test/fixtures/bpmn/throw-event-dataInputAssociations.part.bpmn
@@ -1,5 +1,5 @@
 <bpmn:endEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                id="EndEvent_1">
-  <bpmn:dataInputAssociation id="DataInputAssociation_1"></bpmn:dataInputAssociation>
+  <bpmn:dataInputAssociation id="DataInputAssociation_1" name="DataInputAssociation_1n"></bpmn:dataInputAssociation>
 </bpmn:endEvent>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -217,7 +217,7 @@ describe('bpmn-moddle - read', function() {
           id: 'EndEvent_1',
 
           dataInputAssociations: [
-            { $type: 'bpmn:DataInputAssociation', id: 'DataInputAssociation_1' }
+            { $type: 'bpmn:DataInputAssociation', id: 'DataInputAssociation_1', name: 'DataInputAssociation_1n' }
           ]
         };
 
@@ -240,7 +240,7 @@ describe('bpmn-moddle - read', function() {
           id: 'StartEvent_1',
 
           dataOutputAssociations: [
-            { $type: 'bpmn:DataOutputAssociation', id: 'DataOutputAssociation_1' }
+            { $type: 'bpmn:DataOutputAssociation', id: 'DataOutputAssociation_1', name: 'DataOutputAssociation_1n' }
           ]
         };
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/2333

The spec reasons for this are referenced by our contributor on the above issue. 