### PR TITLE
chore(package.json): change `prepublishOnly` to `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "distro": "run-s build test:build",
     "build": "rollup -c",
     "test:build": "mocha --reporter=spec --recursive test/distro",
-    "prepublishOnly": "run-s distro",
+    "prepare": "run-s distro",
     "generate-schema": "node tasks/generate-schema"
   },
   "repository": {


### PR DESCRIPTION
* This will make this repo `npm link` friendly
* Related: https://forum.bpmn.io/t/how-to-roll-my-own-modeler/7265/6
* Alternative: https://github.com/bpmn-io/bpmn-js/pull/1612
* Suggested by @nikku (props)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
