### PR TITLE
fix: correct the `engine` field to require Node 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,23 @@ All notable changes to [bpmn-moddle](https://github.com/bpmn-io/bpmn-moddle) are
 
 ___Note:__ Yet to be released changes appear here._
 
+## 9.0.1
+
+* `FIX`: correct the `engine` field to require Node 18 ([#113](https://github.com/bpmn-io/bpmn-moddle/issues/113))
+
 ## 9.0.0
 
 * `FEAT`: add `exports` configuration ([#111](https://github.com/bpmn-io/bpmn-moddle/pull/111))
 * `FIX`: remove broken `main` export ([#111](https://github.com/bpmn-io/bpmn-moddle/pull/111))
 * `CHORE`: drop UMD distribution ([#110](https://github.com/bpmn-io/bpmn-moddle/pull/110))
 * `CHORE`: turn into ES module ([#111](https://github.com/bpmn-io/bpmn-moddle/pull/111))
-* `CHORE`: require Node >= 16
+* `CHORE`: require Node >= 18
 * `DEPS`: update to `moddle@7.0.0` ([#109](https://github.com/bpmn-io/bpmn-moddle/pull/109))
 * `DEPS`: update to `moddle-xml@11.0.0` ([#109](https://github.com/bpmn-io/bpmn-moddle/pull/109))
 
 ### Breaking Changes
 
-* Require Node >= 16
+* Require Node >= 18
 * Drop UMD distribution. Use ES module export in modern JavaScript run-times
 
 ## 8.1.0

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "keywords": [
     "bpmn",


### PR DESCRIPTION
This is needed due to using dependencies requiring Node 18.

Closes #113

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
