### PR TITLE
test: verify event definition ref is read correctly

### DIFF
--- a/test/fixtures/bpmn/event-definition-ref.bpmn
+++ b/test/fixtures/bpmn/event-definition-ref.bpmn
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="simple" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn2:timerEventDefinition id="TimerDefinition">
+    <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">date</bpmn2:timeDate>
+  </bpmn2:timerEventDefinition>
+  <bpmn2:process id="Process_1">
+    <bpmn2:startEvent id="StartEvent_1" name="Start Event 1">
+      <bpmn2:eventDefinitionRef>TimerDefinition</bpmn2:eventDefinitionRef>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+</bpmn2:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -501,6 +501,29 @@ describe('bpmn-moddle - read', function() {
 
       });
 
+
+      it('Event#eventDefinitionRef', async function() {
+
+        // when
+        var {
+          elementsById
+        } = await fromFile('test/fixtures/bpmn/event-definition-ref.bpmn');
+
+        // then
+        const eventDefinitionRef = elementsById['StartEvent_1'].get('eventDefinitionRef');
+
+        expect(eventDefinitionRef).to.jsonEqual([
+          {
+            $type: 'bpmn:TimerEventDefinition',
+            id: 'TimerDefinition',
+            timeDate: {
+              $type: 'bpmn:FormalExpression',
+              body: 'date'
+            }
+          }
+        ]);
+      });
+
     });
 
 

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -727,6 +727,23 @@ describe('bpmn-moddle - roundtrip', function() {
       // then
       await validate(xml);
     });
+
+
+    it('event definition ref', async function() {
+
+      // given
+      var {
+        rootElement
+      } = await fromFile('test/fixtures/bpmn/event-definition-ref.bpmn');
+
+      // when
+      var {
+        xml
+      } = await toXML(rootElement, { format: true });
+
+      // then
+      await validate(xml);
+    });
   });
 
 


### PR DESCRIPTION
### Proposed Changes

This PR verifies that bpmn-moddle can read and roundtrip event definition ref.

Related to https://github.com/bpmn-io/bpmn-js/issues/2309

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
