### PR TITLE
fix: remove cancelRemainingInstances default value

### DIFF
--- a/resources/bpmn/json/bpmn.json
+++ b/resources/bpmn/json/bpmn.json
@@ -2599,7 +2599,6 @@
         },
         {
           "name": "cancelRemainingInstances",
-          "default": true,
           "isAttr": true,
           "type": "Boolean"
         }

--- a/tasks/transforms/transformBPMN.cjs
+++ b/tasks/transforms/transformBPMN.cjs
@@ -373,5 +373,7 @@ module.exports = async function(results) {
   // https://github.com/bpmn-io/bpmn-moddle/issues/127
   delete findProperty('MessageEventDefinition#operationRef', model).isAttr;
 
+  delete findProperty('AdHocSubProcess#cancelRemainingInstances', model).default;
+
   return model;
 };

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -536,10 +536,14 @@ describe('bpmn-moddle - roundtrip', function() {
         rootElement
       } = await fromFile('test/fixtures/bpmn/ad-hoc.bpmn');
 
+      // cancelRemainingInstances should not have a default value
+      expect(rootElement.get('cancelRemainingInstances')).not.to.exist;
+
       // when
       var {
         xml
       } = await toXML(rootElement, { format: true });
+
       await validate(xml);
     });
 

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -636,6 +636,7 @@ describe('bpmn-moddle - write', function() {
         // then
         expect(xml).to.eql(expectedXML);
       });
+
     });
 
 


### PR DESCRIPTION
### Proposed Changes

Required to fix https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/4. Ad-hoc sub-processes cannot have a `cancelRemainingInstances` property if they are implemented as a job worker (have a task definition). Therefore they cannot have a default value in the model.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
