### PR TITLE
Fix replaceKey array recursion in transform helper

### DIFF
--- a/tasks/transforms/helper.cjs
+++ b/tasks/transforms/helper.cjs
@@ -410,7 +410,7 @@ function replaceKey(key, newKey, object) {
   // (1) iterate object keys
   Object.entries(object).forEach(entry => {
 
-    if (isArray[ entry[ 1 ]]) {
+    if (isArray(entry[ 1 ])) {
 
       // (2.1) recurse
       entry[ 1 ].forEach(item => replaceKey(key, newKey, item));


### PR DESCRIPTION
### Proposed Changes

This PR fixes a bug in the schema transform helper where replaceKey failed to recurse into arrays.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

