### PR TITLE
Generate bpmn moddle types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "moddle-xml": "^12.1.0"
       },
       "devDependencies": {
+        "@bpmn-io/moddle-types-generator": "^0.2.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "bpmn-in-color-moddle": "^0.2.0",
@@ -37,6 +38,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@bpmn-io/moddle-types-generator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-types-generator/-/moddle-types-generator-0.2.0.tgz",
+      "integrity": "sha512-atKeiFXATK6vgr3n1G/oxWRd31wT1j7Kz22rnMKaR89IUwpjdu73ef+EHl89unpPdAtZ26LjI2zQ98UbCoJl5g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "moddle-generate-types": "bin/generate-types.js"
+      },
+      "engines": {
+        "node": ">=20.12"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5391,6 +5405,12 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
+    "@bpmn-io/moddle-types-generator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-types-generator/-/moddle-types-generator-0.2.0.tgz",
+      "integrity": "sha512-atKeiFXATK6vgr3n1G/oxWRd31wT1j7Kz22rnMKaR89IUwpjdu73ef+EHl89unpPdAtZ26LjI2zQ98UbCoJl5g==",
       "dev": true
     },
     "@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
   "version": "10.0.0",
   "description": "A moddle wrapper for BPMN 2.0",
   "scripts": {
-    "all": "run-s generate-schema lint test",
+    "all": "run-s generate-schema lint generate-types test",
     "lint": "eslint .",
     "dev": "npm test -- --watch",
     "pretest": "run-s build",
     "test": "mocha --reporter=spec --recursive test",
     "build": "rollup -c",
     "prepare": "run-s build",
-    "generate-schema": "node tasks/generate-schema.cjs"
+    "prepublishOnly": "run-s generate-types",
+    "generate-schema": "node tasks/generate-schema.cjs",
+    "generate-types": "moddle-generate-types --index dist/types/index.d.ts resources/bpmn/json/bpmn.json dist/types/bpmn.d.ts resources/bpmn/json/dc.json dist/types/dc.d.ts resources/bpmn/json/di.json dist/types/di.d.ts resources/bpmn/json/bpmndi.json dist/types/bpmndi.d.ts"
   },
   "type": "module",
   "repository": {
@@ -19,6 +21,9 @@
   },
   "exports": {
     ".": "./dist/index.js",
+    "./types": {
+      "types": "./dist/types/index.d.ts"
+    },
     "./resources/*": "./resources/*",
     "./package.json": "./package.json"
   },
@@ -44,6 +49,7 @@
   "license": "MIT",
   "sideEffects": false,
   "devDependencies": {
+    "@bpmn-io/moddle-types-generator": "^0.2.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "bpmn-in-color-moddle": "^0.2.0",


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/internal-docs/issues/1345

Generate TypeScript declarations for the bpmn, dc, di and bpmndi namespaces from the moddle descriptors and expose them via the `bpmn-moddle/types` subpath.

Types are build artifacts, regenerated via `npm run generate-types`(and on `prepublishOnly`).

**Try out:**
1. Run `npm run generate-types`
2. Check the `d.ts` files under `dist/types`

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
